### PR TITLE
Add tabbed pagination UI to admin magic link dashboard

### DIFF
--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -22,38 +22,61 @@
     </header>
 
     <main class="container admin-container">
-      <section class="card admin-card">
-        <header class="admin-card__header">
+      <section class="card sop-hero admin-hero">
+        <header class="admin-hero__header">
           <div>
-            <p class="admin-card__eyebrow">Authentication</p>
-            <h2 class="admin-card__title">Recent magic link requests</h2>
-            <p class="admin-card__subtitle">
+            <p class="sop-hero__eyebrow">Authentication</p>
+            <h2 class="sop-hero__title">Recent magic link requests</h2>
+            <p class="admin-hero__subtitle">
               Monitor one-time login links requested from the public login page. Click any link below to copy it for manual delivery.
             </p>
           </div>
-          <div class="admin-card__actions">
+          <div class="admin-hero__actions">
             <button type="button" id="refresh-button" class="refresh-button">Refresh</button>
           </div>
         </header>
 
-        <div id="token-error" class="token-alert" role="alert" hidden></div>
+        <div class="admin-hero__body">
+          <div id="token-error" class="token-alert" role="alert" hidden></div>
 
-        <div class="token-table-wrapper">
-          <table class="token-table" aria-describedby="token-footnote">
-            <thead>
-              <tr>
-                <th scope="col">Email</th>
-                <th scope="col">Magic link</th>
-                <th scope="col">Requested</th>
-                <th scope="col">Status</th>
-              </tr>
-            </thead>
-            <tbody id="token-table-body"></tbody>
-          </table>
-          <p id="token-empty" class="token-empty" hidden>No magic link requests yet.</p>
+          <div class="admin-tabs" role="tablist" aria-label="Magic link status tabs">
+            <button type="button" class="admin-tab is-active" data-tab="active" role="tab" aria-selected="true">
+              <span class="admin-tab__label">Valid links</span>
+              <span class="admin-tab__count" aria-label="Valid links count">0</span>
+            </button>
+            <button type="button" class="admin-tab" data-tab="used" role="tab" aria-selected="false">
+              <span class="admin-tab__label">Used links</span>
+              <span class="admin-tab__count" aria-label="Used links count">0</span>
+            </button>
+            <button type="button" class="admin-tab" data-tab="expired" role="tab" aria-selected="false">
+              <span class="admin-tab__label">Expired links</span>
+              <span class="admin-tab__count" aria-label="Expired links count">0</span>
+            </button>
+          </div>
+
+          <div class="token-table-wrapper">
+            <table class="token-table" aria-describedby="token-footnote">
+              <thead>
+                <tr>
+                  <th scope="col">Email</th>
+                  <th scope="col">Magic link</th>
+                  <th scope="col">Requested</th>
+                  <th scope="col">Status</th>
+                </tr>
+              </thead>
+              <tbody id="token-table-body"></tbody>
+            </table>
+            <p id="token-empty" class="token-empty" hidden>No magic link requests yet.</p>
+          </div>
+
+          <nav class="token-pagination" aria-label="Magic link pagination">
+            <button type="button" id="token-prev" class="token-page-button" aria-label="Previous page" disabled>Previous</button>
+            <span id="token-page-indicator" class="token-page-indicator" aria-live="polite">Page 1 of 1</span>
+            <button type="button" id="token-next" class="token-page-button" aria-label="Next page" disabled>Next</button>
+          </nav>
         </div>
 
-        <footer class="admin-card__footer" id="token-footnote">
+        <footer class="admin-hero__footer" id="token-footnote">
           <p>
             Links expire 15 minutes after creation and become unavailable after the recipient signs in. Copying a link does not mark it as used.
           </p>

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -1,4 +1,31 @@
 const ADMIN_PATH = '/admin.html';
+const TAB_KEYS = ['active', 'used', 'expired'];
+const ITEMS_PER_PAGE = 8;
+const TAB_TITLES = {
+  active: 'Valid links',
+  used: 'Used links',
+  expired: 'Expired links',
+};
+const TAB_EMPTY_LABEL = {
+  active: 'valid',
+  used: 'used',
+  expired: 'expired',
+};
+
+const tokenState = {
+  entries: [],
+  buckets: {
+    active: [],
+    used: [],
+    expired: [],
+  },
+  pages: {
+    active: 1,
+    used: 1,
+    expired: 1,
+  },
+  currentTab: 'active',
+};
 
 function getApiBaseUrl() {
   const meta = document.querySelector('meta[name="api-base-url"]');
@@ -116,7 +143,14 @@ function markAccessDenied(user) {
   if (refresh) {
     refresh.disabled = true;
   }
-  setTableEmptyState(true);
+  document.querySelectorAll('.admin-tab').forEach((tab) => {
+    tab.disabled = true;
+    tab.setAttribute('aria-disabled', 'true');
+  });
+  document.querySelectorAll('.token-page-button').forEach((button) => {
+    button.disabled = true;
+  });
+  setTableEmptyState(true, 'Access restricted.');
 }
 
 async function requireAdmin() {
@@ -149,13 +183,16 @@ function showError(message) {
   }
 }
 
-function setTableEmptyState(isEmpty) {
+function setTableEmptyState(isEmpty, message) {
   const table = document.querySelector('.token-table');
   const empty = document.getElementById('token-empty');
   if (table) {
     table.classList.toggle('is-empty', isEmpty);
   }
   if (empty) {
+    if (isEmpty && message) {
+      empty.textContent = message;
+    }
     empty.hidden = !isEmpty;
   }
 }
@@ -241,20 +278,28 @@ function createLinkButton(url) {
   return button;
 }
 
-function renderTokens(items) {
+function clearTokenRows() {
+  const tbody = document.getElementById('token-table-body');
+  if (tbody) {
+    tbody.textContent = '';
+  }
+}
+
+function renderTokenRows(entries) {
   const tbody = document.getElementById('token-table-body');
   if (!tbody) return;
   tbody.textContent = '';
 
-  if (!Array.isArray(items) || items.length === 0) {
-    setTableEmptyState(true);
+  if (!Array.isArray(entries) || entries.length === 0) {
     return;
   }
 
   const template = document.getElementById('token-row-template');
+  if (!template) return;
+
   const frag = document.createDocumentFragment();
 
-  items.forEach((item) => {
+  entries.forEach((entry) => {
     const clone = template.content.firstElementChild.cloneNode(true);
     const emailCell = clone.querySelector('[data-key="email"]');
     const linkCell = clone.querySelector('[data-key="verifyUrl"]');
@@ -262,17 +307,19 @@ function renderTokens(items) {
     const statusCell = clone.querySelector('[data-key="status"]');
 
     if (emailCell) {
-      emailCell.textContent = item.email;
+      emailCell.textContent = entry.email || '';
     }
     if (linkCell) {
       linkCell.textContent = '';
-      linkCell.appendChild(createLinkButton(item.verifyUrl));
+      if (entry.verifyUrl) {
+        linkCell.appendChild(createLinkButton(entry.verifyUrl));
+      }
     }
     if (createdCell) {
-      createdCell.textContent = formatTimestamp(item.createdAt);
+      createdCell.textContent = formatTimestamp(entry.createdAt);
     }
     if (statusCell) {
-      const status = deriveStatus(item);
+      const status = entry.status || deriveStatus(entry);
       const badge = document.createElement('span');
       badge.className = `token-status-badge token-status-${status.code}`;
       badge.textContent = status.label;
@@ -284,7 +331,131 @@ function renderTokens(items) {
   });
 
   tbody.appendChild(frag);
-  setTableEmptyState(false);
+}
+
+function getEmptyMessage(status) {
+  const label = TAB_EMPTY_LABEL[status] || 'magic';
+  return `No ${label} magic links yet.`;
+}
+
+function getPageDetails(status) {
+  const bucket = tokenState.buckets[status] || [];
+  const totalItems = bucket.length;
+  if (totalItems === 0) {
+    tokenState.pages[status] = 1;
+    return { items: [], page: 0, totalPages: 0, totalItems };
+  }
+
+  const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
+  let page = tokenState.pages[status] || 1;
+  if (page > totalPages) {
+    page = totalPages;
+  }
+  if (page < 1) {
+    page = 1;
+  }
+  tokenState.pages[status] = page;
+
+  const startIndex = (page - 1) * ITEMS_PER_PAGE;
+  const items = bucket.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  return { items, page, totalPages, totalItems };
+}
+
+function updatePaginationDisplay(status, details) {
+  const prev = document.getElementById('token-prev');
+  const next = document.getElementById('token-next');
+  const indicator = document.getElementById('token-page-indicator');
+  const hasPages = details.totalItems > 0 && details.totalPages > 0;
+
+  if (prev) {
+    prev.disabled = !hasPages || details.page <= 1;
+    prev.setAttribute('aria-disabled', prev.disabled ? 'true' : 'false');
+  }
+  if (next) {
+    next.disabled = !hasPages || details.page >= details.totalPages;
+    next.setAttribute('aria-disabled', next.disabled ? 'true' : 'false');
+  }
+  if (indicator) {
+    if (!hasPages) {
+      const label = TAB_EMPTY_LABEL[status] || 'magic';
+      indicator.textContent = `No ${label} links yet`;
+    } else {
+      indicator.textContent = `Page ${details.page} of ${details.totalPages} · ${details.totalItems} total`;
+    }
+  }
+}
+
+function renderCurrentView() {
+  if (!TAB_KEYS.includes(tokenState.currentTab)) {
+    tokenState.currentTab = 'active';
+  }
+
+  const details = getPageDetails(tokenState.currentTab);
+  if (details.totalItems === 0) {
+    clearTokenRows();
+    setTableEmptyState(true, getEmptyMessage(tokenState.currentTab));
+  } else {
+    setTableEmptyState(false);
+    renderTokenRows(details.items);
+  }
+  updatePaginationDisplay(tokenState.currentTab, details);
+}
+
+function renderTabs() {
+  document.querySelectorAll('.admin-tab').forEach((button) => {
+    const key = button.dataset.tab;
+    const bucket = tokenState.buckets[key] || [];
+    const countEl = button.querySelector('.admin-tab__count');
+    if (countEl) {
+      countEl.textContent = bucket.length;
+      countEl.setAttribute('aria-label', `${TAB_TITLES[key] || 'Links'} count: ${bucket.length}`);
+    }
+    const isActive = key === tokenState.currentTab;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-selected', String(isActive));
+    if (button.disabled) {
+      button.disabled = false;
+      button.removeAttribute('aria-disabled');
+    }
+  });
+}
+
+function normalizeTokenEntries(items) {
+  if (!Array.isArray(items)) return [];
+  return items
+    .map((item) => ({
+      ...item,
+      status: deriveStatus(item),
+    }))
+    .sort((a, b) => {
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime;
+    });
+}
+
+function applyTokenData(items) {
+  tokenState.entries = normalizeTokenEntries(items);
+  const buckets = {
+    active: [],
+    used: [],
+    expired: [],
+  };
+
+  tokenState.entries.forEach((entry) => {
+    const key = TAB_KEYS.includes(entry.status.code) ? entry.status.code : 'active';
+    buckets[key].push(entry);
+  });
+
+  tokenState.buckets = buckets;
+  tokenState.pages = {
+    active: 1,
+    used: 1,
+    expired: 1,
+  };
+
+  renderTabs();
+  renderCurrentView();
 }
 
 async function loadTokens() {
@@ -306,12 +477,66 @@ async function loadTokens() {
       throw new Error(`Request failed: ${res.status}`);
     }
     const data = await res.json();
-    renderTokens(data.items || []);
+    applyTokenData(data.items || []);
   } catch (err) {
     console.error('Failed to load magic link requests', err);
     showError('Unable to load magic link requests. Try refreshing in a moment.');
   } finally {
     if (refresh) refresh.disabled = false;
+  }
+}
+
+function changePage(delta) {
+  const status = TAB_KEYS.includes(tokenState.currentTab) ? tokenState.currentTab : 'active';
+  const bucket = tokenState.buckets[status] || [];
+  if (bucket.length === 0) {
+    tokenState.pages[status] = 1;
+    return;
+  }
+
+  const totalPages = Math.ceil(bucket.length / ITEMS_PER_PAGE);
+  let page = tokenState.pages[status] || 1;
+  page += delta;
+  if (page < 1) page = 1;
+  if (page > totalPages) page = totalPages;
+  tokenState.pages[status] = page;
+  renderCurrentView();
+}
+
+function setupTabs() {
+  const tablist = document.querySelector('.admin-tabs');
+  if (!tablist) return;
+
+  tablist.addEventListener('click', (event) => {
+    const button = event.target.closest('.admin-tab');
+    if (!button || button.disabled) return;
+    const tab = button.dataset.tab;
+    if (!tab) return;
+    event.preventDefault();
+    const key = TAB_KEYS.includes(tab) ? tab : 'active';
+    if (tokenState.currentTab === key) return;
+    tokenState.currentTab = key;
+    renderTabs();
+    renderCurrentView();
+  });
+}
+
+function setupPagination() {
+  const prev = document.getElementById('token-prev');
+  const next = document.getElementById('token-next');
+
+  if (prev) {
+    prev.addEventListener('click', (event) => {
+      event.preventDefault();
+      changePage(-1);
+    });
+  }
+
+  if (next) {
+    next.addEventListener('click', (event) => {
+      event.preventDefault();
+      changePage(1);
+    });
   }
 }
 
@@ -366,6 +591,9 @@ async function init() {
   if (!user) return;
 
   setupCopyHandler();
+  setupTabs();
+  setupPagination();
+  renderTabs();
 
   const refresh = document.getElementById('refresh-button');
   if (refresh) {

--- a/frontend/public/styles/base.css
+++ b/frontend/public/styles/base.css
@@ -879,6 +879,154 @@ button.danger:hover {
     margin: 0;
 }
 
+.admin-hero {
+    display: grid;
+    gap: 28px;
+}
+
+.admin-hero__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.admin-hero__subtitle {
+    margin: 8px 0 0;
+    max-width: 60ch;
+    color: rgba(31, 41, 55, 0.76);
+    font-size: 15px;
+    line-height: 1.6;
+}
+
+.admin-hero__actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.admin-hero__body {
+    display: grid;
+    gap: 22px;
+}
+
+.admin-hero__footer {
+    margin: 0;
+    font-size: 13px;
+    color: var(--fg-muted);
+}
+
+.admin-tabs {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.55);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.admin-tab {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    color: rgba(31, 41, 55, 0.7);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    transition: color var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.admin-tab__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 26px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(81, 97, 255, 0.12);
+    color: var(--accent-2);
+    font-size: 12px;
+}
+
+.admin-tab.is-active {
+    background: rgba(81, 97, 255, 0.18);
+    color: var(--accent-2);
+    box-shadow: 0 12px 24px rgba(81, 97, 255, 0.18);
+}
+
+.admin-tab.is-active .admin-tab__count {
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--accent-2);
+    box-shadow: inset 0 0 0 1px rgba(81, 97, 255, 0.35);
+}
+
+.admin-tab:hover,
+.admin-tab:focus-visible {
+    color: var(--accent-2);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.admin-tab:focus-visible {
+    box-shadow: 0 0 0 2px rgba(81, 97, 255, 0.28);
+}
+
+.admin-tab[disabled] {
+    cursor: not-allowed;
+    opacity: 0.55;
+    transform: none;
+}
+
+.token-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 18px;
+    border-radius: var(--radius);
+    background: rgba(255, 255, 255, 0.75);
+    border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.token-page-button {
+    border: none;
+    background: rgba(81, 97, 255, 0.16);
+    color: var(--accent-2);
+    font: inherit;
+    font-weight: 600;
+    padding: 10px 18px;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.token-page-button:hover:not(:disabled),
+.token-page-button:focus-visible {
+    transform: translateY(-1px);
+    background: rgba(81, 97, 255, 0.24);
+    box-shadow: 0 10px 20px rgba(81, 97, 255, 0.22);
+    outline: none;
+}
+
+.token-page-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+.token-page-indicator {
+    font-size: 14px;
+    color: var(--fg-muted);
+}
+
 .refresh-button {
     border: 1px solid rgba(81, 97, 255, 0.35);
     background: linear-gradient(135deg, rgba(81, 97, 255, 0.1), rgba(81, 97, 255, 0.2));
@@ -1049,6 +1197,36 @@ button.danger:hover {
 
     .token-timestamp {
         min-width: auto;
+    }
+
+    .admin-hero__header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .admin-hero__actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .admin-tabs {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .token-pagination {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: center;
+        gap: 12px;
+    }
+
+    .token-page-button {
+        width: 100%;
+    }
+
+    .token-page-indicator {
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
## Summary
- restyle the admin magic link panel to use the SOP hero layout with tabbed status navigation and pagination controls
- add supporting styles for the hero shell, tabs, pagination, and responsive behavior
- refactor the admin dashboard script to categorize tokens, render tab counts, and paginate each status bucket

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6900b82f4d9c832b80d0f49f4cd61624